### PR TITLE
Add light/dark mode theme toggle to title bar

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -19,7 +19,7 @@
             <Style x:Key="TitleBarButtonStyle" TargetType="Button">
                 <Setter Property="Background" Value="Transparent"/>
                 <Setter Property="BorderBrush" Value="Transparent"/>
-                <Setter Property="Foreground" Value="#333"/>
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryText}"/>
                 <Setter Property="FontSize" Value="16"/>
                 <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Cursor" Value="Hand"/>

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -10,6 +10,10 @@ namespace Winton
         {
             base.OnStartup(e);
 
+            // Apply saved theme before any UI is shown
+            var savedTheme = Services.ThemeConfig.LoadTheme();
+            SetTheme(savedTheme);
+
             // Keep the app alive while Splash is open
             ShutdownMode = ShutdownMode.OnExplicitShutdown;
 

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -42,6 +42,13 @@
                             VerticalAlignment="Center"
                             Margin="0,0,10,0">
 
+                    <Button x:Name="ThemeToggleButton"
+                            Content="🌙"
+                            Width="46" Height="30"
+                            Style="{StaticResource TitleBarButtonStyle}"
+                            ToolTip="Toggle Dark / Light Mode"
+                            Click="ThemeToggle_Click"/>
+
                     <Button Content="—"
                             Width="46" Height="30"
                             Style="{StaticResource TitleBarButtonStyle}"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -16,10 +16,15 @@ namespace Winton
     {
         private EditableSalesFloor _salesFloor;
         private Button _activeNavBtn;
+        private bool _isDarkMode;
 
         public MainWindow()
         {
             InitializeComponent();
+
+            // Sync toggle icon with the theme that was already applied at startup
+            _isDarkMode = Services.ThemeConfig.LoadTheme() == "Dark";
+            ThemeToggleButton.Content = _isDarkMode ? "☀" : "🌙";
 
             Loaded += async (s, e) =>
             {
@@ -115,6 +120,15 @@ namespace Winton
                 // If dragging while maximized, restore first (optional Windows-like behavior)
                 DragMove();
             }
+        }
+
+        private void ThemeToggle_Click(object sender, RoutedEventArgs e)
+        {
+            _isDarkMode = !_isDarkMode;
+            var themeName = _isDarkMode ? "Dark" : "Light";
+            (App.Current as App).SetTheme(themeName);
+            Services.ThemeConfig.SaveTheme(themeName);
+            ThemeToggleButton.Content = _isDarkMode ? "☀" : "🌙";
         }
 
         private void Minimize_Click(object sender, RoutedEventArgs e)

--- a/Services/ThemeConfig.cs
+++ b/Services/ThemeConfig.cs
@@ -1,0 +1,35 @@
+using System.IO;
+
+namespace Winton.Services
+{
+    internal static class ThemeConfig
+    {
+        private static readonly string ThemeFilePath =
+            Path.Combine(DatabaseConfig.AppDataFolder, "theme.txt");
+
+        public static string LoadTheme()
+        {
+            try
+            {
+                if (File.Exists(ThemeFilePath))
+                {
+                    var saved = File.ReadAllText(ThemeFilePath).Trim();
+                    if (saved == "Dark" || saved == "Light")
+                        return saved;
+                }
+            }
+            catch { }
+            return "Light";
+        }
+
+        public static void SaveTheme(string themeName)
+        {
+            try
+            {
+                Directory.CreateDirectory(DatabaseConfig.AppDataFolder);
+                File.WriteAllText(ThemeFilePath, themeName);
+            }
+            catch { }
+        }
+    }
+}


### PR DESCRIPTION
- New ThemeConfig service persists theme choice to AppData/Wintonx/theme.txt
- App.xaml.cs loads saved theme before any UI is shown
- Theme toggle button (☀/🌙) added to title bar, left of window controls
- MainWindow.xaml.cs wires up toggle handler and syncs icon on load
- Fix TitleBarButtonStyle foreground to use DynamicResource PrimaryText so icons are visible in both themes

https://claude.ai/code/session_01R4FcnQjAHw1UiuK9j3oMKk