### PR TITLE
Code cleanup: remove dead code, extract constants, fix inefficiencies

### DIFF
--- a/Helpers/SectionInteraction.cs
+++ b/Helpers/SectionInteraction.cs
@@ -9,7 +9,6 @@ namespace Winton.Helpers
     public class SectionInteraction
     {
         private bool _isDragging = false;
-        private bool _isResizing = false;
         private Point _startPosition;
         private UIElement _selectedElement;
 
@@ -62,7 +61,6 @@ namespace Winton.Helpers
             _selectedElement?.ReleaseMouseCapture();
         }
 
-        // 🔥 New Method: Find the Parent Canvas Correctly
         private Canvas GetParentCanvas(UIElement element)
         {
             DependencyObject parent = element;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -106,7 +106,6 @@ namespace Winton
 
         private void Maximize_Click(object sender, RoutedEventArgs e) => ToggleWindowState();
 
-        //adding a comment for testing git
         private void TitleBar_MouseDown(object sender, MouseButtonEventArgs e)
         {
             if (e.ClickCount == 2 && e.ChangedButton == MouseButton.Left)
@@ -183,10 +182,7 @@ namespace Winton
             MainContent.Content = _salesFloor;
         }
 
-        public EditableSalesFloor SalesFloorInstance
-        {
-            get { return _salesFloor; }
-        }
+        public EditableSalesFloor SalesFloorInstance => _salesFloor;
 
         public void SetMainContent(UserControl control)
         {

--- a/Services/ImportServices.cs
+++ b/Services/ImportServices.cs
@@ -13,6 +13,8 @@ namespace Winton.Services
     /// </summary>
     internal class ImportServices
     {
+        private static readonly HashSet<string> ValidTransactionCodes = new() { "00", "05", "07", "30", "37" };
+
         /// <summary>
         /// Imports a sales report from an Excel file and saves it to the database.
         /// </summary>
@@ -58,26 +60,17 @@ namespace Winton.Services
                                         continue;
                                     }
 
-                                    // Determine revenue based on transaction code
-                                    decimal revenue = 0;
-                                    bool validTransaction = transactionCode switch
-                                    {
-                                        "00" or "05" or "07" => true,  // Normal sales transactions
-                                        "30" or "37" => true,  // Returns/refunds (negative revenue)
-                                        _ => false
-                                    };
-
-                                    if (!validTransaction)
+                                    if (!ValidTransactionCodes.Contains(transactionCode))
                                     {
                                         Debug.WriteLine($"[ImportServices] Ignoring row {row}: unsupported transaction code {transactionCode}.");
                                         continue;
                                     }
 
-                                    revenue = transactionCode switch
+                                    decimal revenue = transactionCode switch
                                     {
-                                        "00" or "05" or "07" => price * quantitySold,  // Standard sales
-                                        "30" or "37" => -(price * quantitySold), // Refunds
-                                        _ => 0
+                                        "00" or "05" or "07" => price * quantitySold,
+                                        "30" or "37"         => -(price * quantitySold),
+                                        _                    => 0
                                     };
 
                                     // Insert data into SalesData table
@@ -218,9 +211,7 @@ namespace Winton.Services
                             continue;
                         }
 
-                        // Check transaction code
-                        var validCodes = new HashSet<string> { "00", "05", "07", "30", "37" };
-                        if (string.IsNullOrEmpty(transactionCode) || !validCodes.Contains(transactionCode))
+                        if (string.IsNullOrEmpty(transactionCode) || !ValidTransactionCodes.Contains(transactionCode))
                         {
                             Debug.WriteLine($"[ImportServices] Skipping row {rowIndex}: invalid transaction code '{transactionCode}'.");
                             continue;

--- a/Services/SalesDataServices.cs
+++ b/Services/SalesDataServices.cs
@@ -11,7 +11,7 @@ namespace Winton.Services
     /// </summary>
     internal class SalesDataServices
     {
-        private static string ConnectionString => $"Data Source={DatabaseConfig.DbPath};";
+        private static readonly string ConnectionString = $"Data Source={DatabaseConfig.DbPath};";
 
         /// <summary>
         /// Retrieves the total revenue for the current year.
@@ -72,17 +72,18 @@ namespace Winton.Services
                 using var connection = new SqliteConnection(ConnectionString);
                 await connection.OpenAsync();
 
+                const string query = @"
+                    SELECT SUM(Revenue)
+                    FROM SalesData
+                    WHERE strftime('%Y', SaleDate) = @Year AND strftime('%m', SaleDate) = @Month";
+
+                using var command = new SqliteCommand(query, connection);
+                command.Parameters.AddWithValue("@Year", year.ToString());
+                command.Parameters.Add("@Month", SqliteType.Text);
+
                 for (int month = 1; month <= 12; month++)
                 {
-                    string query = @"
-                        SELECT SUM(Revenue) 
-                        FROM SalesData 
-                        WHERE strftime('%Y', SaleDate) = @Year AND strftime('%m', SaleDate) = @Month";
-
-                    using var command = new SqliteCommand(query, connection);
-                    command.Parameters.AddWithValue("@Year", year.ToString());
-                    command.Parameters.AddWithValue("@Month", month.ToString("D2"));
-
+                    command.Parameters["@Month"].Value = month.ToString("D2");
                     var result = await command.ExecuteScalarAsync();
                     values.Add(result != DBNull.Value && result != null ? Convert.ToDecimal(result) : 0);
                 }
@@ -238,12 +239,12 @@ namespace Winton.Services
 
             try
             {
-                using var connection = new SqliteConnection($"Data Source={DatabaseConfig.DbPath};");
+                using var connection = new SqliteConnection(ConnectionString);
                 await connection.OpenAsync();
 
                 string query = @"
-            SELECT ItemNumber, VendorModel, Description, Price, QuantitySold, Revenue, Cat, Grp, TransactionCode 
-            FROM SalesData 
+            SELECT ItemNumber, VendorModel, Description, Price, QuantitySold, Revenue, Cat, Grp, TransactionCode
+            FROM SalesData
             WHERE date(SaleDate) = date(@ReportDate)";
 
                 using var command = new SqliteCommand(query, connection);

--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -65,6 +65,9 @@ namespace Winton.ViewModels
 
         public Func<double, string> Formatter { get; } = v => ((decimal)v).ToString("C0");
 
+        private static readonly Brush GreenBrush = new SolidColorBrush(Color.FromRgb(52, 199, 89));
+        private static readonly Brush RedBrush   = new SolidColorBrush(Color.FromRgb(255, 69, 58));
+
         // Kept for DetailedChartWindow compatibility
         public SeriesCollection CurrentYearRevenue  { get; private set; } = new();
         public SeriesCollection PreviousYearRevenue { get; private set; } = new();
@@ -188,9 +191,7 @@ namespace Winton.ViewModels
             double pct = (double)((current - previous) / Math.Abs(previous) * 100);
             bool positive = pct >= 0;
             string arrow = positive ? "▲" : "▼";
-            Brush brush   = positive
-                ? new SolidColorBrush(Color.FromRgb(52, 199, 89))
-                : new SolidColorBrush(Color.FromRgb(255, 69, 58));
+            Brush brush   = positive ? GreenBrush : RedBrush;
             return ($"{arrow} {Math.Abs(pct):F0}% {label}", brush);
         }
 

--- a/ViewModels/ProductListViewModel.cs
+++ b/ViewModels/ProductListViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using Winton.Models;
 
 namespace Winton.Views
@@ -15,7 +16,7 @@ namespace Winton.Views
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        protected void OnPropertyChanged(string name)
+        protected void OnPropertyChanged([CallerMemberName] string name = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }

--- a/ViewModels/SectionDetailViewModel.cs
+++ b/ViewModels/SectionDetailViewModel.cs
@@ -23,7 +23,7 @@ namespace Winton.ViewModels
         public int TotalQuantitySold { get; set; }
 
         public decimal AvgRevenuePerProduct =>
-            ProductBreakdown != null && ProductBreakdown.Count > 0
+            ProductBreakdown.Count > 0
                 ? Math.Round(TotalRevenue / ProductBreakdown.Count, 2)
                 : 0;
 

--- a/Views/ReportDetailsControl.xaml.cs
+++ b/Views/ReportDetailsControl.xaml.cs
@@ -16,7 +16,7 @@ namespace Winton.Views
         {
             InitializeComponent();
             _reportDate = reportDate;
-            Loaded += async (s, e) => await LoadReportDetailsAsync(); ;
+            Loaded += async (s, e) => await LoadReportDetailsAsync();
         }
 
         private async Task LoadReportDetailsAsync()

--- a/Views/ReportsListControl.xaml.cs
+++ b/Views/ReportsListControl.xaml.cs
@@ -10,6 +10,8 @@ namespace Winton.Views
     /// </summary>
     public partial class ReportsListControl : UserControl
     {
+        private const string DateFormat = "MMM dd, yyyy";
+
         public List<ReportDateDisplay> Reports { get; set; }
         public ReportsListControl()
         {
@@ -21,16 +23,9 @@ namespace Winton.Views
         {
             try
             {
-                // Get reports from the last 2 years asynchronously
                 var reportDates = await SalesDataServices.GetReportsFromLastTwoYearsAsync();
-
-                // Ensure data is not null before using it
-                if (reportDates != null)
-                {
-                    // Format dates and bind to the list
-                    Reports = reportDates.Select(r => new ReportDateDisplay { DisplayDate = r.ToString("MMM dd, yyyy"), ReportDate = r }).ToList();
-                    lstReports.ItemsSource = Reports;
-                }
+                Reports = reportDates.Select(r => new ReportDateDisplay { DisplayDate = r.ToString(DateFormat), ReportDate = r }).ToList();
+                lstReports.ItemsSource = Reports;
             }
             catch (Exception ex)
             {
@@ -66,14 +61,12 @@ namespace Winton.Views
                 string filename = dlg.FileName;
 
                 // Open a dialog to get the report date
-                var dialog = new FileNameWindow(DateTime.Now.ToString("MMM dd, yyyy"), DateTime.Now);
+                var dialog = new FileNameWindow(DateTime.Now.ToString(DateFormat), DateTime.Now);
 
                 if (dialog.ShowDialog() == true)
                 {
                     DateTime reportDate = dialog.ReportDate;
-
-                    // Automatically update the filename to match the selected date
-                    string newFilename = reportDate.ToString("MMM dd, yyyy");
+                    string newFilename = reportDate.ToString(DateFormat);
 
                     try
                     {


### PR DESCRIPTION
- MainWindow.xaml.cs: remove leftover git-test comment; simplify SalesFloorInstance to expression-bodied property
- SectionInteraction.cs: remove unused _isResizing field; remove stale emoji comment
- ReportsListControl.xaml.cs: extract DateFormat constant; remove redundant null check on GetReportsFromLastTwoYearsAsync result
- ReportDetailsControl.xaml.cs: remove double semicolon typo on Loaded handler
- SalesDataServices.cs: make ConnectionString static readonly (was re-evaluated on every access); remove one-off inline connection string in GetReportDetailsByDateAsync; reuse SqliteCommand across the 12-month loop instead of creating a new object per iteration
- DashboardViewModel.cs: extract static GreenBrush/RedBrush to avoid allocating new SolidColorBrush objects on each BuildDelta call
- SectionDetailViewModel.cs: remove redundant null guard on ProductBreakdown (initialized as new())
- ImportServices.cs: hoist ValidTransactionCodes to a class-level static readonly HashSet; removes duplicate inline HashSet allocated on every imported row
- ProductListViewModel.cs: add [CallerMemberName] to OnPropertyChanged so callers no longer need to pass the property name string manually

https://claude.ai/code/session_01R4FcnQjAHw1UiuK9j3oMKk